### PR TITLE
changed translated word "default" to "varsayılan"

### DIFF
--- a/po/tr/kcm_componentchooser.po
+++ b/po/tr/kcm_componentchooser.po
@@ -28,7 +28,7 @@ msgstr ""
 #: browser_settings.kcfg:9
 #, kde-format
 msgid "Default web browser"
-msgstr "Öntanımlı web tarayıcı"
+msgstr "Varsayılan web tarayıcı"
 
 #: componentchooser.cpp:74 componentchooserterminal.cpp:74
 #, kde-format
@@ -38,32 +38,32 @@ msgstr "Diğer…"
 #: componentchooserbrowser.cpp:18
 #, kde-format
 msgid "Select default browser"
-msgstr "Öntanımlı tarayıcıyı seç"
+msgstr "Varsayılan tarayıcıyı seç"
 
 #: componentchooseremail.cpp:19
 #, kde-format
 msgid "Select default e-mail client"
-msgstr "Öntanımlı e-posta istemcisini seç"
+msgstr "Varsayılan e-posta istemcisini seç"
 
 #: componentchooserfilemanager.cpp:14
 #, kde-format
 msgid "Select default file manager"
-msgstr "Öntanımlı dosya yöneticisi'ni seç"
+msgstr "Varsayılan dosya yöneticisi'ni seç"
 
 #: componentchoosergeo.cpp:11
 #, kde-format
 msgid "Select default map"
-msgstr "Öntanımlı harita uygulamasını seç"
+msgstr "Varsayılan harita uygulamasını seç"
 
 #: componentchoosertel.cpp:15
 #, kde-format
 msgid "Select default dialer application"
-msgstr "Öntanımlı çevirici uygulamasını seç"
+msgstr "Varsayılan çevirici uygulamasını seç"
 
 #: componentchooserterminal.cpp:24
 #, kde-format
 msgid "Select default terminal emulator"
-msgstr "Öntanımlı uçbirim öykünücüyü seç"
+msgstr "Varsayılan uçbirim öykünücüyü seç"
 
 #: package/contents/ui/main.qml:30
 #, kde-format

--- a/po/tr/kcm_desktoppaths.po
+++ b/po/tr/kcm_desktoppaths.po
@@ -110,7 +110,7 @@ msgstr "Belgeler yolu:"
 msgid ""
 "This folder will be used by default to load or save documents from or to."
 msgstr ""
-"Bu klasör, belgelerinizi kaydetmek için öntanımlı konum olarak kullanılır."
+"Bu klasör, belgelerinizi kaydetmek için varsayılan konum olarak kullanılır."
 
 #. i18n: ectx: property (text), widget (QLabel, label_4)
 #: globalpaths.ui:51
@@ -123,7 +123,7 @@ msgstr "İndirilenler yolu:"
 #, kde-format
 msgid "This folder will be used by default to save your downloaded items."
 msgstr ""
-"Bu klasör, indirilen dosyalarınızı kaydetmek için öntanımlı konum olarak "
+"Bu klasör, indirilen dosyalarınızı kaydetmek için varsayılan konum olarak "
 "kullanılır."
 
 #. i18n: ectx: property (text), widget (QLabel, label_5)
@@ -137,7 +137,7 @@ msgstr "Videolar yolu:"
 #, kde-format
 msgid "This folder will be used by default to load or save movies from or to."
 msgstr ""
-"Bu klasör, filmlerinizi kaydetmek için öntanımlı konum olarak kullanılır."
+"Bu klasör, filmlerinizi kaydetmek için varsayılan konum olarak kullanılır."
 
 #. i18n: ectx: property (text), widget (QLabel, label_6)
 #: globalpaths.ui:85
@@ -151,7 +151,7 @@ msgstr "Resimler yolu:"
 msgid ""
 "This folder will be used by default to load or save pictures from or to."
 msgstr ""
-"Bu klasör, resim dosyalarınızı kaydetmek için öntanımlı konum olarak "
+"Bu klasör, resim dosyalarınızı kaydetmek için varsayılan konum olarak "
 "kullanılır."
 
 #. i18n: ectx: property (text), widget (QLabel, label_7)
@@ -165,7 +165,7 @@ msgstr "Müzikler yolu:"
 #, kde-format
 msgid "This folder will be used by default to load or save music from or to."
 msgstr ""
-"Bu klasör, müziklerinizi kaydetmek için öntanımlı konum olarak kullanılır."
+"Bu klasör, müziklerinizi kaydetmek için varsayılan konum olarak kullanılır."
 
 #. i18n: ectx: property (text), widget (QLabel, label_8)
 #: globalpaths.ui:119
@@ -180,7 +180,7 @@ msgid ""
 "This folder will be used by default to load or save public shares from or to."
 msgstr ""
 "Bu klasör, genel paylaşımlardan yüklemek veya paylaşımlara kaydetmek için "
-"öntanımlı konum olarak kullanılır."
+"varsayılan konum olarak kullanılır."
 
 #. i18n: ectx: property (text), widget (QLabel, label_9)
 #: globalpaths.ui:136
@@ -194,5 +194,5 @@ msgstr "Şablonlar yolu:"
 msgid ""
 "This folder will be used by default to load or save templates from or to."
 msgstr ""
-"Bu klasör, şablonlardan yüklemek veya şablonları kaydetmek için öntanımlı "
+"Bu klasör, şablonlardan yüklemek veya şablonları kaydetmek için varsayılan "
 "konum olarak kullanılır."

--- a/po/tr/kcm_keys.po
+++ b/po/tr/kcm_keys.po
@@ -198,23 +198,23 @@ msgstr "Etkin kısayol yok"
 msgctxt "%1 decides if singular or plural will be used"
 msgid "Default shortcut"
 msgid_plural "Default shortcuts"
-msgstr[0] "Öntanımlı kısayol"
-msgstr[1] "Öntanımlı kısayollar"
+msgstr[0] "Varsayılan kısayol"
+msgstr[1] "Varsayılan kısayollar"
 
 #: package/contents/ui/ShortcutActionDelegate.qml:94
 #, kde-format
 msgid "No default shortcuts"
-msgstr "Öntanımlı kısayol yok"
+msgstr "Varsayılan kısayol yok"
 
 #: package/contents/ui/ShortcutActionDelegate.qml:102
 #, kde-format
 msgid "Default shortcut %1 is enabled."
-msgstr "%1 öntanımlı kısayolu etkinleştirildi."
+msgstr "%1 Varsayılan kısayolu etkinleştirildi."
 
 #: package/contents/ui/ShortcutActionDelegate.qml:102
 #, kde-format
 msgid "Default shortcut %1 is disabled."
-msgstr "%1 öntanımlı kısayolu devre dışı bırakıldı."
+msgstr "%1 Varsayılan kısayolu devre dışı bırakıldı."
 
 #: package/contents/ui/ShortcutActionDelegate.qml:123
 #, kde-format

--- a/po/tr/kcm_smserver.po
+++ b/po/tr/kcm_smserver.po
@@ -103,7 +103,7 @@ msgstr ""
 #: package/contents/ui/main.qml:97
 #, kde-format
 msgid "Default option:"
-msgstr "Öntanımlı seçenek:"
+msgstr "Varsayılan seçenek:"
 
 #: package/contents/ui/main.qml:98
 #, kde-format
@@ -222,7 +222,7 @@ msgstr "Çıkışı onayla"
 #: smserversettings.kcfg:13
 #, kde-format
 msgid "Default leave option"
-msgstr "Öntanımlı çıkış seçeneği"
+msgstr "Varsayılan çıkış seçeneği"
 
 #. i18n: ectx: label, entry (loginMode), group (General)
 #: smserversettings.kcfg:22

--- a/po/tr/kcm_tablet.po
+++ b/po/tr/kcm_tablet.po
@@ -21,7 +21,7 @@ msgstr ""
 #: kcmtablet.cpp:32
 #, kde-format
 msgid "Primary (default)"
-msgstr "Birincil (öntanımlı)"
+msgstr "Birincil (varsayılan)"
 
 #: kcmtablet.cpp:33
 #, kde-format

--- a/po/tr/kcm_touchpad.po
+++ b/po/tr/kcm_touchpad.po
@@ -426,7 +426,7 @@ msgid ""
 "Error while loading default values. Failed to set some options to their "
 "default values."
 msgstr ""
-"Öntanımlı değerler yüklenirken hata oluştu. Bazı seçenekleri öntanımlı "
+"Varsayılan değerler yüklenirken hata oluştu. Bazı seçenekleri varsayılan "
 "değerlerine ayarlama başarısız."
 
 #: kcm/libinput/touchpadconfiglibinput.cpp:142

--- a/po/tr/kcmkeyboard.po
+++ b/po/tr/kcmkeyboard.po
@@ -359,7 +359,7 @@ msgstr "Kısayol"
 #, kde-format
 msgctxt "variant"
 msgid "Default"
-msgstr "Öntanımlı"
+msgstr "Varsayılan"
 
 #. i18n: ectx: property (text), widget (QLabel, label_2)
 #: kcmmiscwidget.ui:31

--- a/po/tr/kcmmouse.po
+++ b/po/tr/kcmmouse.po
@@ -107,7 +107,7 @@ msgid ""
 "Error while loading default values. Failed to set some options to their "
 "default values."
 msgstr ""
-"Öntanımlı değerler yüklenirken hata oluştu. Bazı seçenekleri öntanımlı "
+"Varsayılan değerler yüklenirken hata oluştu. Bazı seçenekleri varsayılan "
 "değerlerine ayarlama başarısız."
 
 #: kcm/libinput/libinput_config.cpp:167

--- a/po/tr/plasma_applet_org.kde.desktopcontainment.po
+++ b/po/tr/plasma_applet_org.kde.desktopcontainment.po
@@ -354,7 +354,7 @@ msgstr "Hiçbiri"
 #: package/contents/ui/ConfigLocation.qml:183
 #, kde-format
 msgid "Default"
-msgstr "Öntanımlı"
+msgstr "Varsayılan"
 
 #: package/contents/ui/ConfigLocation.qml:183
 #, kde-format

--- a/po/tr/plasma_applet_org.kde.plasma.kickoff.po
+++ b/po/tr/plasma_applet_org.kde.plasma.kickoff.po
@@ -66,7 +66,7 @@ msgid ""
 "Current icon is %1. Click to open menu to change the current icon or reset "
 "to the default icon."
 msgstr ""
-"Geçerli simge %1. Menüyü açıp geçerli simgeyi değiştirmek veya öntanımlı "
+"Geçerli simge %1. Menüyü açıp geçerli simgeyi değiştirmek veya varsayılan "
 "simgeye geri dönmek için tıklayın."
 
 #: package/contents/ui/ConfigGeneral.qml:76
@@ -85,7 +85,7 @@ msgstr "Uygulama Başlatıcı için bir simge seç"
 #, kde-format
 msgctxt "@item:inmenu Reset icon to default"
 msgid "Reset to default icon"
-msgstr "Öntanımlı simgeye sıfırla"
+msgstr "Varsayılan simgeye sıfırla"
 
 #: package/contents/ui/ConfigGeneral.qml:88
 #, kde-format

--- a/po/tr/plasma_applet_org.kde.plasma.pager.po
+++ b/po/tr/plasma_applet_org.kde.plasma.pager.po
@@ -55,7 +55,7 @@ msgstr "Yerleşim:"
 #, kde-format
 msgctxt "The pager layout"
 msgid "Default"
-msgstr "Öntanımlı"
+msgstr "Varsayılan"
 
 #: package/contents/ui/configGeneral.qml:66
 #, kde-format


### PR DESCRIPTION
I changed this word because "default" doesn't to mean "öntanımlı" (partially)
Example : 
![image](https://user-images.githubusercontent.com/72016401/209851429-347ffb1f-4ff8-4c3d-8932-9c93c4cdc3cc.png)
