### PR TITLE
Adding password length faker to the passwordBox

### DIFF
--- a/desktoppackage/contents/lockscreen/MainBlock.qml
+++ b/desktoppackage/contents/lockscreen/MainBlock.qml
@@ -42,6 +42,8 @@ SessionManagementScreen {
     }
 
     function startLogin() {
+        // Stripe the fake length characters
+        passwordBox.text = passwordBox.text.replace(/▀/g,'');
         const password = passwordBox.text
 
         // This is partly because it looks nicer, but more importantly it
@@ -88,6 +90,10 @@ SessionManagementScreen {
                     userList.incrementCurrentIndex();
                     event.accepted = true
                 }
+                //Appending fake characters to every character added to mask the password length
+                var spaces = ['','▀','▀▀'];
+                var number = Math.floor(Math.random() * spaces.length);               
+                passwordBox.text = passwordBox.text+spaces[number]; 
             }
 
             Connections {


### PR DESCRIPTION
Appending  some characters that is not found on any keyboard layout to every character inserted in the passwordBox. the appended characters length is random between 0 to 2.

The importance of faking password length: To reduce the probability of any physical observer to determine the password length.