### PR TITLE
Always display Volume controls in tooltip

### DIFF
--- a/applets/taskmanager/package/contents/ui/ToolTipInstance.qml
+++ b/applets/taskmanager/package/contents/ui/ToolTipInstance.qml
@@ -332,7 +332,6 @@ ColumnLayout {
     Loader {
         active: toolTipDelegate.parentTask !== null
              && pulseAudio.item !== null
-             && toolTipDelegate.parentTask.audioIndicatorsEnabled
              && toolTipDelegate.parentTask.hasAudioStream
              && root.index !== -1 // Avoid loading when the instance is going to be destroyed
         asynchronous: true


### PR DESCRIPTION
BUG: https://bugs.kde.org/show_bug.cgi?id=494906

Always display Volume controls in tooltip regardless of 'Mark applications that play audio' setting.