### PR TITLE
Fix typo in Kickoff: uruchamiana -> uruchamiania

### DIFF
--- a/applets/kickoff/package/metadata.json
+++ b/applets/kickoff/package/metadata.json
@@ -143,7 +143,7 @@
         "Description[nl]": "Applet voor het starten van programma's",
         "Description[nn]": "Moderne programstartar",
         "Description[pa]": "ਐਪਲੀਕੇਸ਼ਨ ਚਲਾਉਣ ਲਈ ਲਾਂਚਰ",
-        "Description[pl]": "Uruchamiacz do uruchamiana programów",
+        "Description[pl]": "Uruchamiacz do uruchamiania programów",
         "Description[pt]": "Lançador para iniciar aplicações",
         "Description[pt_BR]": "Lançador para iniciar aplicativos",
         "Description[ro]": "Lansator pentru a porni aplicații",


### PR DESCRIPTION
Typo in `applets/kickoff/package/metadata.json` line 146 - it should be "Uruchamiacz do uruchamiania programów", not "Uruchamiacz do uruchamiana programów"