### PR TITLE
Reduce wait time after wrong password entered on lock screen to 777ms

### DIFF
--- a/desktoppackage/contents/lockscreen/LockScreenUi.qml
+++ b/desktoppackage/contents/lockscreen/LockScreenUi.qml
@@ -178,7 +178,7 @@ Item {
         }
         Timer {
             id: graceLockTimer
-            interval: 3000
+            interval: 777
             onTriggered: {
                 root.clearPassword();
                 authenticator.startAuthenticating();


### PR DESCRIPTION
TODO make it configurable via KDE settings. maybe file `lockscreen/config.xml` can be used as bridge between KDE Settings UI and LockScreenUI?