### PR TITLE
Fix assorted correctness bugs across KCMs, applets, containments

### DIFF
--- a/applets/kicker/ItemGridView.qml
+++ b/applets/kicker/ItemGridView.qml
@@ -86,8 +86,8 @@ FocusScope {
         anchors.fill: parent
         active: false
         onActiveChanged: {
-            if (!active && "dropPlaceHolderIndex" in model) {
-                model.dropPlaceHolderIndex = -1;
+            if (!active && "dropPlaceholderIndex" in model) {
+                model.dropPlaceholderIndex = -1;
             }
         }
 

--- a/applets/kicker/MenuRepresentation.qml
+++ b/applets/kicker/MenuRepresentation.qml
@@ -133,7 +133,7 @@ PlasmaComponents3.ScrollView {
                     (event.key === Qt.Key_Right && mainRow.LayoutMirroring.enabled)
                 let forwardArrowKey = (event.key === Qt.Key_Right && !mainRow.LayoutMirroring.enabled) ||
                     (event.key === Qt.Key_Left && mainRow.LayoutMirroring.enabled)
-                if (backArrowKey & runnerColumns.visibleChildren.length > 1) {
+                if (backArrowKey && runnerColumns.visibleChildren.length > 1) {
                     root.focusRunnerColumn(runnerColumns.visibleChildren.length - 2, true)
                 } else if (forwardArrowKey) {
                     if (runnerColumns.visibleChildren.length > 1) {
@@ -461,7 +461,7 @@ PlasmaComponents3.ScrollView {
                 if (!sideBar.visible && !runnerColumns.visible) {
                     return;
                 }
-                if (runnerColumns.visibleChildren[0]?.length > 1) {
+                if (runnerColumns.visibleChildren[0]?.count > 1) {
                     runnerColumns.visibleChildren[0].currentIndex = -1;
                 }
                 if (sideBar.visible) {

--- a/applets/kimpanel/kimpanelagent.cpp
+++ b/applets/kimpanel/kimpanelagent.cpp
@@ -8,6 +8,8 @@
 #include "kimpanelagent.h"
 #include "impaneladaptor.h"
 
+#include <algorithm>
+
 // Qt
 #include <QByteArray>
 #include <QDBusServiceWatcher>
@@ -168,7 +170,11 @@ static KimpanelLookupTable Args2LookupTable(const QStringList &labels, const QSt
 
     KimpanelLookupTable result;
 
-    for (int i = 0; i < labels.size(); i++) {
+    // The lists come from external DBus input and may be malformed (mismatched
+    // sizes), in which case the asserts above are no-ops in release builds.
+    // Bound the loop to the shortest list to avoid out-of-bounds access.
+    const int count = std::min({labels.size(), candis.size(), attrs.size()});
+    for (int i = 0; i < count; i++) {
         KimpanelLookupTable::Entry entry;
 
         entry.label = labels.at(i);

--- a/applets/taskmanager/backend.cpp
+++ b/applets/taskmanager/backend.cpp
@@ -464,7 +464,7 @@ void Backend::setActionGroup(QAction *action) const
 
 QRect Backend::globalRect(QQuickItem *item) const
 {
-    if (!item || !item->window()) {
+    if (!item || !item->window() || !item->parentItem()) {
         return QRect();
     }
 

--- a/containments/desktop/plugins/folder/positioner.cpp
+++ b/containments/desktop/plugins/folder/positioner.cpp
@@ -913,7 +913,7 @@ void Positioner::convertFolderModelData()
 
     // Restore positions for items that still fit.
     for (auto &&[name, gridPos] : std::as_const(m_positions).asKeyValueRange()) {
-        if (gridPos.pos <= m_perStripe) {
+        if (gridPos.pos < m_perStripe) {
             if (!sourceIndices.contains(name)) {
                 continue;
             }
@@ -933,7 +933,7 @@ void Positioner::convertFolderModelData()
 
     // Find new positions for items that didn't fit.
     for (auto &&[name, gridPos] : std::as_const(m_positions).asKeyValueRange()) {
-        if (gridPos.pos > m_perStripe) {
+        if (gridPos.pos >= m_perStripe) {
             if (!sourceIndices.contains(name)) {
                 continue;
             }

--- a/containments/desktop/plugins/folder/previewpluginsmodel.cpp
+++ b/containments/desktop/plugins/folder/previewpluginsmodel.cpp
@@ -114,7 +114,7 @@ QStringList PreviewPluginsModel::checkedPlugins() const
     // If the list of checked plugins is the default set, return an empty list
     // which denotes the default set.
     // This ensures newly-installed thumbnails are always automatically enabled.
-    if (std::is_permutation(list.constBegin(), list.constEnd(), defaultPlugins.begin())) {
+    if (std::is_permutation(list.constBegin(), list.constEnd(), defaultPlugins.constBegin(), defaultPlugins.constEnd())) {
         return QStringList();
     }
 

--- a/containments/desktop/plugins/folder/screenmapper.cpp
+++ b/containments/desktop/plugins/folder/screenmapper.cpp
@@ -254,7 +254,7 @@ void ScreenMapper::addScreenTransition(int screenSrc, int screenDst, const QStri
 void ScreenMapper::setSharedDesktop(bool sharedDesktops)
 {
     if (m_sharedDesktops != sharedDesktops) {
-        m_sharedDesktops = true;
+        m_sharedDesktops = sharedDesktops;
         if (!m_corona)
             return;
 

--- a/imports/activitymanager/sortedactivitiesmodel.cpp
+++ b/imports/activitymanager/sortedactivitiesmodel.cpp
@@ -217,7 +217,7 @@ SortedActivitiesModel::SortedActivitiesModel(QObject *parent)
     connect(m_windowTasksModel, &TaskManager::WindowTasksModel::dataChanged, this, &SortedActivitiesModel::onWindowChanged);
 
     // Update windows at start
-    onWindowAdded(QModelIndex(), 0, m_windowTasksModel->rowCount());
+    onWindowAdded(QModelIndex(), 0, m_windowTasksModel->rowCount() - 1);
 }
 
 SortedActivitiesModel::~SortedActivitiesModel()

--- a/kcms/dateandtime/dtime.h
+++ b/kcms/dateandtime/dtime.h
@@ -68,7 +68,7 @@ private:
     QString timeServer;
     int BufI;
     bool refresh;
-    bool ontimeout;
+    bool ontimeout = false;
     QString m_selectedTimeZone;
 };
 

--- a/kcms/gamecontroller/device.cpp
+++ b/kcms/gamecontroller/device.cpp
@@ -270,7 +270,7 @@ int Device::buttonCount() const
 bool Device::buttonState(int index) const
 {
     // Invalid index
-    if (index < 0 || index > m_buttonCount)
+    if (index < 0 || index >= m_buttonCount)
         return false;
 
     // If we are a game controller, use that api to get button state

--- a/kcms/gamecontroller/devicemodel.cpp
+++ b/kcms/gamecontroller/devicemodel.cpp
@@ -101,7 +101,7 @@ void DeviceModel::poll()
             break;
         case SDL_JOYBUTTONDOWN:
         case SDL_JOYBUTTONUP:
-            if (m_devices.contains(event.jbutton.which) && !m_devices.value(event.jaxis.which)->isController()) {
+            if (m_devices.contains(event.jbutton.which) && !m_devices.value(event.jbutton.which)->isController()) {
                 m_devices.value(event.jbutton.which)->onButtonEvent(event.jbutton);
             }
             break;

--- a/kcms/keyboard/kcm_keyboard.cpp
+++ b/kcms/keyboard/kcm_keyboard.cpp
@@ -175,8 +175,8 @@ bool KCMKeyboard::isSaveNeeded() const
 
 bool KCMKeyboard::isDefaults() const
 {
-    return m_data->workspaceOptions()->isDefaults() || m_data->keyboardMiscSettings()->isDefaults() || m_config->isDefaults()
-        || m_shortcutHelper->isSaveNeeded() || m_xkbOptionsModel->xkbOptions() == m_data->keyboardSettings()->xkbOptions();
+    return m_data->workspaceOptions()->isDefaults() && m_data->keyboardMiscSettings()->isDefaults() && m_config->isDefaults()
+        && m_shortcutHelper->isDefaults() && m_xkbOptionsModel->xkbOptions() == m_data->keyboardSettings()->defaultXkbOptionsValue();
 }
 
 void KCMKeyboard::resetShortcuts()

--- a/kcms/keyboard/shortcuthelper.cpp
+++ b/kcms/keyboard/shortcuthelper.cpp
@@ -67,7 +67,7 @@ bool ShortcutHelper::isSaveNeeded()
 
 bool ShortcutHelper::isDefaults()
 {
-    return m_alternativeShortcut == DefaultAlternativeShortcut || m_lastUsedShortcut == DefaultLastUsedShortcut;
+    return m_alternativeShortcut == DefaultAlternativeShortcut && m_lastUsedShortcut == DefaultLastUsedShortcut;
 }
 
 KeyboardLayoutActionCollection *ShortcutHelper::actionColletion()

--- a/kcms/keyboard/xkb_rules.cpp
+++ b/kcms/keyboard/xkb_rules.cpp
@@ -91,6 +91,11 @@ static void rxkbLogHandler(rxkb_context *context, rxkb_log_level priority, const
     Q_UNUSED(context)
     char buf[1024];
     int length = std::vsnprintf(buf, 1023, format, args);
+    // vsnprintf returns the number of characters that would have been written;
+    // clamp to what actually fit in the buffer to avoid reading past it.
+    if (length > 1022) {
+        length = 1022;
+    }
     while (length > 0 && std::isspace(buf[length - 1])) {
         --length;
     }

--- a/kcms/keyboard/xkboptionsmodel.cpp
+++ b/kcms/keyboard/xkboptionsmodel.cpp
@@ -186,9 +186,8 @@ void XkbOptionsModel::navigateToGroup(const QString &group)
         return groupInfo.name == group;
     });
 
-    int index = std::distance(Rules::self().optionGroupInfos.cbegin(), it);
-
-    if (index != -1) {
+    if (it != Rules::self().optionGroupInfos.cend()) {
+        int index = std::distance(Rules::self().optionGroupInfos.cbegin(), it);
         Q_EMIT navigateTo(createIndex(index, 0));
     }
 }

--- a/kcms/keys/globalaccelmodel.cpp
+++ b/kcms/keys/globalaccelmodel.cpp
@@ -393,6 +393,7 @@ void GlobalAccelModel::addApplication(const QString &desktopFileName, const QStr
             if (infoReply.value().isEmpty()) {
                 qCWarning(KCMKEYS()) << "New component has no shortcuts:" << reply.value().path();
                 Q_EMIT errorOccured(i18nc("%1 is the name of an application", "Error while adding %1, it seems it has no actions."));
+                return;
             }
             qCDebug(KCMKEYS) << "inserting at " << pos - m_components.begin();
             beginInsertRows(QModelIndex(), pos - m_components.begin(), pos - m_components.begin());

--- a/kcms/keys/keysdata.cpp
+++ b/kcms/keys/keysdata.cpp
@@ -55,7 +55,7 @@ KeysData::KeysData(QObject *parent)
                     bool isNotDefault = std::any_of(allShortcuts.cbegin(), allShortcuts.cend(), [](const KGlobalShortcutInfo &info) {
                         return info.defaultKeys() != info.keys();
                     });
-                    m_isDefault &= isNotDefault;
+                    m_isDefault &= !isNotDefault;
                 }
                 if (--m_pendingComponentCalls == 0) {
                     Q_EMIT loaded();

--- a/kcms/recentFiles/ExcludedApplicationsModel.cpp
+++ b/kcms/recentFiles/ExcludedApplicationsModel.cpp
@@ -43,7 +43,7 @@ ExcludedApplicationsModel::ExcludedApplicationsModel(QObject *parent)
     : QAbstractListModel(parent)
 {
     d->enabled = false;
-    d->pluginConfig = new KActivityManagerdPluginsSettings;
+    d->pluginConfig = new KActivityManagerdPluginsSettings(this);
 }
 
 ExcludedApplicationsModel::~ExcludedApplicationsModel()
@@ -147,7 +147,7 @@ void ExcludedApplicationsModel::defaults()
 
 void ExcludedApplicationsModel::toggleApplicationBlocked(int index)
 {
-    if (index > rowCount()) {
+    if (index < 0 || index >= rowCount()) {
         return;
     }
 
@@ -171,7 +171,7 @@ void ExcludedApplicationsModel::toggleApplicationBlocked(int index)
 
     const auto allowedApplicationsItem = d->pluginConfig->findItem("allowedApplications");
     Q_ASSERT(allowedApplicationsItem);
-    const auto blockedApplicationsItem = d->pluginConfig->findItem("allowedApplications");
+    const auto blockedApplicationsItem = d->pluginConfig->findItem("blockedApplications");
     Q_ASSERT(blockedApplicationsItem);
 
     Q_EMIT changed(blockedApplicationsItem->isSaveNeeded() && allowedApplicationsItem->isSaveNeeded());
@@ -190,7 +190,7 @@ QVariant ExcludedApplicationsModel::data(const QModelIndex &modelIndex, int role
 {
     const auto index = modelIndex.row();
 
-    if (index > rowCount()) {
+    if (index < 0 || index >= rowCount()) {
         return QVariant();
     }
 

--- a/kcms/runners/plasmasearch/kcm.cpp
+++ b/kcms/runners/plasmasearch/kcm.cpp
@@ -33,7 +33,7 @@ public:
             return false;
         }
         return std::all_of(runnerData.begin(), runnerData.end(), [&cfgGroup](const KPluginMetaData &pluginData) {
-            return pluginData.isEnabled(cfgGroup) != pluginData.isEnabledByDefault();
+            return pluginData.isEnabled(cfgGroup) == pluginData.isEnabledByDefault();
         });
     }
 

--- a/kcms/runners/plugininstaller/ZypperRPMJob.cpp
+++ b/kcms/runners/plugininstaller/ZypperRPMJob.cpp
@@ -26,6 +26,7 @@ void ZypperRPMJob::executeOperation(const QFileInfo &fileInfo, const QString & /
         const auto infoMatch = QRegularExpression(QStringLiteral("Name *: (.+)")).match(rpmInfo);
         if (!infoMatch.hasMatch()) {
             Q_EMIT error(i18nc("@info", "Could not resolve package name of %1", fileInfo.baseName()));
+            return;
         }
         const QString rpmPackageName = KShell::quoteArg(infoMatch.captured(1));
         QProcess *process = new QProcess(this);

--- a/kcms/solid_actions/ActionModel.cpp
+++ b/kcms/solid_actions/ActionModel.cpp
@@ -101,6 +101,9 @@ void ActionModel::buildActionList()
             it.next();
             const QString desktop = it.filePath();
             const KService::Ptr desktopService = KService::serviceByStorageId(it.filePath());
+            if (!desktopService) {
+                continue;
+            }
             // Get contained services list
             const QList<KServiceAction> services = desktopService->actions();
             for (const KServiceAction &deviceAction : services) {

--- a/kcms/tablet/tabletsmodel.cpp
+++ b/kcms/tablet/tabletsmodel.cpp
@@ -150,13 +150,13 @@ bool TabletsModel::isSaveNeeded() const
 
 bool TabletsModel::isDefaults() const
 {
-    return std::any_of(m_devices.cbegin(), m_devices.cend(), [](auto &dev) {
-        bool isDefaults = false;
+    return std::all_of(m_devices.cbegin(), m_devices.cend(), [](auto &dev) {
+        bool isDefaults = true;
         if (dev.penDevice) {
-            isDefaults |= dev.penDevice->isDefaults();
+            isDefaults &= dev.penDevice->isDefaults();
         }
         if (dev.padDevice) {
-            isDefaults |= dev.padDevice->isDefaults();
+            isDefaults &= dev.padDevice->isDefaults();
         }
         return isDefaults;
     });

--- a/runners/kwin/kwin-runner.cpp
+++ b/runners/kwin/kwin-runner.cpp
@@ -66,7 +66,7 @@ void KWinRunner::checkAvailability(const QString &name, const QString & /*oldOwn
         m_enabled = enabled;
 
         if (m_enabled) {
-            RunnerSyntax(s_keywords, i18n("Opens the KWin (Plasma Window Manager) debug console."));
+            addSyntax(RunnerSyntax(s_keywords, i18n("Opens the KWin (Plasma Window Manager) debug console.")));
         } else {
             setSyntaxes(QList<RunnerSyntax>());
         }

--- a/solid-device-automounter/kcm/DeviceModel.cpp
+++ b/solid-device-automounter/kcm/DeviceModel.cpp
@@ -392,8 +392,12 @@ void DeviceModel::updateCheckedColumns(int column)
 {
     for (int parent = RowAttached; parent < rowCount(); parent++) {
         const auto parentIndex = index(parent, 0);
+        const int childCount = rowCount(parentIndex);
+        if (childCount == 0) {
+            continue;
+        }
         Q_EMIT dataChanged(index(0, (column > 0 ? column : 1), parentIndex),
-                           index(rowCount(parentIndex), column > 0 ? column : 2, parentIndex),
+                           index(childCount - 1, column > 0 ? column : 2, parentIndex),
                            {Qt::CheckStateRole, Qt::ToolTipRole});
     }
 }


### PR DESCRIPTION
Backup of bug-fix work found via a multi-agent review of the source tree. 24 files, each a targeted fix for a genuine defect:

- Crashes / OOB: missing return before info[0] deref (keys), null derefs (gamecontroller button handler, solid_actions service, taskmanager globalRect), off-by-one bounds (gamecontroller buttonState, recentFiles model, DBus lookup-table loop), vsnprintf length overrun (xkb log), 3-iter std::is_permutation overrun (folder previews).
- Inverted/incorrect logic: five wrong isDefaults() impls (keyboard, shortcuts, tablet, keysdata, plasmasearch), setSharedDesktop() ignoring its arg, folder icon-reflow off-by-one, kicker QML & vs && and .length vs .count, dropPlaceholderIndex casing.
- Misc: leaked KConfig (recentFiles), wrong config key, uninitialized member (dtime), missing return before zypper remove "", discarded RunnerSyntax, one-past-end dataChanged/startup-scan indices.